### PR TITLE
Handle non-logged in user, polish some style & states

### DIFF
--- a/components/MainActionBox.tsx
+++ b/components/MainActionBox.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Box } from "@primer/components";
+
+export const MainActionBox: React.FC = ({ children }) => (
+  <Box
+    display="flex"
+    flexDirection="column"
+    alignItems="center"
+    padding={8}
+    borderWidth={1}
+    borderStyle="solid"
+    borderColor="border.default"
+    borderRadius={16}
+    bg="canvas.subtle"
+    width="100%"
+    maxWidth={400}
+  >
+    {children}
+  </Box>
+);

--- a/components/MainActionBox.tsx
+++ b/components/MainActionBox.tsx
@@ -1,7 +1,10 @@
 import React from "react";
-import { Box } from "@primer/components";
+import { Box, BoxProps } from "@primer/components";
 
-export const MainActionBox: React.FC = ({ children }) => (
+export const MainActionBox: React.FC<BoxProps> = ({
+  children,
+  ...boxProps
+}) => (
   <Box
     display="flex"
     flexDirection="column"
@@ -14,6 +17,7 @@ export const MainActionBox: React.FC = ({ children }) => (
     bg="canvas.subtle"
     width="100%"
     maxWidth={400}
+    {...boxProps}
   >
     {children}
   </Box>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,12 +1,12 @@
-import { Avatar, ButtonOutline, Header, Text, Box } from '@primer/components'
-import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
-import { supabase } from '../pages/_app';
-import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+import { Avatar, ButtonOutline, Header, Text, Box } from "@primer/components";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import { supabase } from "../pages/_app";
+import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
 
 type HeaderProps = {
-  showAvatar: boolean,
-}
+  showAvatar: boolean;
+};
 
 const CustomHeader = ({ showAvatar }: HeaderProps) => {
   const router = useRouter();
@@ -15,21 +15,30 @@ const CustomHeader = ({ showAvatar }: HeaderProps) => {
   const user = session?.user;
   const userMeta = user?.user_metadata;
 
-  const [isAuthenticated, setIsAuthenticated] = useState(session != null)
-  const [avatarUrl, setAvatarUrl] = useState("https://github.com/octocat.png")
+  const [isAuthenticated, setIsAuthenticated] = useState(session !== null);
+  const [avatarUrl, setAvatarUrl] = useState("https://github.com/octocat.png");
 
-  supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
-    if (event == "SIGNED_IN" || event == "USER_UPDATED") {
-      setAvatarUrl(session?.user?.user_metadata.avatar_url);
-      setIsAuthenticated(true);
+  supabase.auth.onAuthStateChange(
+    (event: AuthChangeEvent, session: Session | null) => {
+      if (event == "SIGNED_IN" || event == "USER_UPDATED") {
+        setAvatarUrl(session?.user?.user_metadata.avatar_url);
+        setIsAuthenticated(true);
+      }
     }
-  });
+  );
 
   useEffect(() => {
     if (isAuthenticated) {
       setAvatarUrl(userMeta?.avatar_url);
     }
-  }, [isAuthenticated, userMeta?.avatar_url])
+  }, [isAuthenticated, userMeta?.avatar_url]);
+
+  const handleLogout = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (!error) {
+      router.push(`/`);
+    }
+  };
 
   return (
     <Header>
@@ -38,17 +47,34 @@ const CustomHeader = ({ showAvatar }: HeaderProps) => {
           <span>GitHub Chat</span>
         </Header.Link>
       </Header.Item>
-      <Header.Item full>
-      </Header.Item>
-      {showAvatar && isAuthenticated && <Header.Item mr={0}>
-        <Box display="flex" flexDirection="row" alignItems="center">
-          <Avatar src={avatarUrl!} size={32} square alt={userMeta?.user_name} />
-          <Text fontWeight="bold" paddingLeft={2}>{userMeta?.user_name}</Text>
-        </Box>
-      </Header.Item>}
-      {showAvatar && !isAuthenticated && <ButtonOutline variant="small" onClick={() => router.push("/login")} >Login</ButtonOutline>}
+      <Header.Item full></Header.Item>
+      {isAuthenticated && (
+        <ButtonOutline marginRight={2} variant="small" onClick={handleLogout}>
+          Logout
+        </ButtonOutline>
+      )}
+      {showAvatar && isAuthenticated && (
+        <Header.Item mr={0}>
+          <Box display="flex" flexDirection="row" alignItems="center">
+            <Avatar
+              src={avatarUrl!}
+              size={32}
+              square
+              alt={userMeta?.user_name}
+            />
+            <Text fontWeight="bold" paddingLeft={2}>
+              {userMeta?.user_name}
+            </Text>
+          </Box>
+        </Header.Item>
+      )}
+      {showAvatar && !isAuthenticated && (
+        <ButtonOutline variant="small" onClick={() => router.push("/login")}>
+          Login
+        </ButtonOutline>
+      )}
     </Header>
   );
-}
+};
 
 export default CustomHeader;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -17,7 +17,11 @@ function MyApp({ Component, pageProps }: AppProps) {
 
   if (typeof window !== "undefined") {
     let tempTheme = localStorage.getItem("theme");
-    if(tempTheme == null || tempTheme == undefined || !["day", "night"].includes(tempTheme)) {
+    if (
+      tempTheme == null ||
+      tempTheme == undefined ||
+      !["day", "night"].includes(tempTheme)
+    ) {
       theme = "night";
       localStorage.setItem("theme", theme);
     } else {
@@ -30,7 +34,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider dayScheme="light" nightScheme="dark" colorMode={theme}>
         <BaseStyles className={"root"}>
-          <Box bg={"bg.primary"} className={"root"} height="100%">
+          <Box bg="canvas.default" className="root" height="100%">
             <Component {...pageProps} />
           </Box>
         </BaseStyles>

--- a/pages/chats/[chat].tsx
+++ b/pages/chats/[chat].tsx
@@ -9,7 +9,12 @@ import {
   Spinner,
   Button,
 } from "@primer/components";
-import { PlusIcon, StopIcon, SyncIcon } from "@primer/octicons-react";
+import {
+  PlusIcon,
+  StopIcon,
+  SyncIcon,
+  CommentDiscussionIcon,
+} from "@primer/octicons-react";
 import { supabase } from "../_app";
 import Header from "../../components/header";
 import Message from "../../components/message";
@@ -22,14 +27,11 @@ const ViewChat: NextPage = () => {
   const { chat: id } = router.query;
 
   const session = supabase.auth.session();
-  const isAuthenticated = session != null;
-
   const userMeta = session?.user?.user_metadata;
 
-  if (typeof window !== "undefined") {
-    if (!isAuthenticated) {
-      router.push(`/login?redirect=/`);
-    }
+  const isAuthenticated = session !== null;
+  if (typeof window !== "undefined" && !isAuthenticated) {
+    router.push(`/login?redirect=/chats/${id}`);
   }
 
   /**
@@ -56,7 +58,7 @@ const ViewChat: NextPage = () => {
 
   useEffect(() => {
     (async () => {
-      if (userMeta != null) {
+      if (userMeta !== null) {
         const { data, error } = await supabase
           .from("members")
           .select(
@@ -123,8 +125,12 @@ const ViewChat: NextPage = () => {
 
       return data || [];
     },
-    { enabled: !!id }
+    { enabled: !!id && isAuthenticated }
   );
+
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <Box height="100%" display="flex" flexDirection="column">
@@ -185,7 +191,9 @@ const ViewChat: NextPage = () => {
           </SideNav>
         </Box>
         <Box width="75%" height="100%" padding={3}>
-          {(isMessagesLoading || !!messagesError) && (
+          {(isMessagesLoading ||
+            !!messagesError ||
+            (messages && messages.length === 0)) && (
             <Box
               height="100%"
               width="100%"
@@ -194,24 +202,43 @@ const ViewChat: NextPage = () => {
               justifyContent="center"
               alignItems="center"
             >
-              {isMessagesLoading && !messages && (
-                <>
-                  <Spinner margin={2} size="medium" />
-                  <Text>Loading messages...</Text>
-                </>
-              )}
-              {!!messagesError && !isMessagesLoading && (
-                <>
-                  <StopIcon size="medium" />
-                  <Text mt={2}>
-                    Something went wrong trying to load messages.
-                  </Text>
-                  <Button mt={3} onClick={() => refetchMessages()}>
-                    <SyncIcon size="small" />
-                    <Text ml={2}>Retry</Text>
-                  </Button>
-                </>
-              )}
+              <Box
+                display="flex"
+                flexDirection="column"
+                alignItems="center"
+                maxWidth={400}
+              >
+                {/* Loading */}
+                {isMessagesLoading && !messages && (
+                  <>
+                    <Spinner margin={2} size="medium" />
+                    <Text>Loading messages...</Text>
+                  </>
+                )}
+                {/* Error fetching messages */}
+                {!!messagesError && !isMessagesLoading && (
+                  <>
+                    <StopIcon size="medium" />
+                    <Text mt={2} textAlign="center">
+                      Something went wrong trying to load messages.
+                    </Text>
+                    <Button mt={3} onClick={() => refetchMessages()}>
+                      <SyncIcon size="small" />
+                      <Text ml={2}>Retry</Text>
+                    </Button>
+                  </>
+                )}
+                {/* There are no messages yet */}
+                {messages && messages.length === 0 && (
+                  <>
+                    <CommentDiscussionIcon size="medium" />
+                    <Text mt={2} textAlign="center">
+                      {"There are no messages yet."} <br />
+                      {"Be the first one to write something!"}
+                    </Text>
+                  </>
+                )}
+              </Box>
             </Box>
           )}
           {messages &&

--- a/pages/chats/[chat].tsx
+++ b/pages/chats/[chat].tsx
@@ -136,7 +136,7 @@ const ViewChat: NextPage = () => {
     <Box height="100%" display="flex" flexDirection="column">
       <Header showAvatar={true} />
       <Box
-        bg="bg.primary"
+        bg="canvas.default"
         display="flex"
         flexDirection="row"
         alignItems="start"

--- a/pages/chats/new.tsx
+++ b/pages/chats/new.tsx
@@ -20,6 +20,7 @@ import { useMutation } from "react-query";
 import { Chat } from "../../types";
 import { useForm } from "react-hook-form";
 import { XIcon } from "@primer/octicons-react";
+import { MainActionBox } from "../../components/MainActionBox";
 
 type FormValues = {
   owner: string;
@@ -136,17 +137,9 @@ const NewChat: NextPage = () => {
         width="100%"
       >
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Box
-            bg="bg.secondary"
-            padding={6}
-            display="flex"
-            flexDirection="column"
-            alignItems="flex-start"
-            width="100%"
-            maxWidth="520px"
-          >
-            <Text as="h3" margin={0}>
-              Create a new Chat!
+          <MainActionBox maxWidth={520}>
+            <Text as="h1" margin={0}>
+              Create a new Chat
             </Text>
             <Box
               display="flex"
@@ -206,14 +199,17 @@ const NewChat: NextPage = () => {
             {createChatError && (
               <Flash marginTop={3} sx={{ width: "100%" }} variant="danger">
                 <StyledOcticon icon={XIcon} />
-                {(createChatError as Error)?.message || "Failed to create chat"}
+                <Text fontSize={1}>
+                  {(createChatError as Error)?.message ||
+                    "Failed to create chat"}
+                </Text>
               </Flash>
             )}
             <ButtonPrimary
               marginTop={4}
               disabled={isLoading}
               variant="large"
-              minWidth={164}
+              width="100%"
               sx={{
                 display: "flex",
                 justifyContent: "center",
@@ -230,7 +226,7 @@ const NewChat: NextPage = () => {
                 <>Create Chat</>
               )}
             </ButtonPrimary>
-          </Box>
+          </MainActionBox>
         </form>
       </Box>
     </Box>

--- a/pages/chats/new.tsx
+++ b/pages/chats/new.tsx
@@ -124,8 +124,6 @@ const NewChat: NextPage = () => {
     return null;
   }
 
-  console.log(errors);
-
   return (
     <Box display="flex" flexDirection="column" height="100%" width="100%">
       <Header showAvatar={true} />

--- a/pages/chats/new.tsx
+++ b/pages/chats/new.tsx
@@ -10,6 +10,7 @@ import {
   Dropdown,
   Flash,
   Spinner,
+  StyledOcticon,
 } from "@primer/components";
 import { supabase } from "../_app";
 import Header from "../../components/header";
@@ -18,6 +19,7 @@ import { Octokit } from "@octokit/rest";
 import { useMutation } from "react-query";
 import { Chat } from "../../types";
 import { useForm } from "react-hook-form";
+import { XIcon } from "@primer/octicons-react";
 
 type FormValues = {
   owner: string;
@@ -29,16 +31,10 @@ const NewChat: NextPage = () => {
   const { code } = router.query;
 
   const session = supabase.auth.session();
-  const isAuthenticated = session != null;
-
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      if (!isAuthenticated) {
-        router.push(`/login?redirect=/chat/new`);
-        return;
-      }
-    }
-  }, [isAuthenticated, router]);
+  const isAuthenticated = session !== null;
+  if (typeof window !== "undefined" && !isAuthenticated) {
+    router.push(`/login?redirect=/chats/new`);
+  }
 
   const {
     mutate: createChat,
@@ -124,6 +120,12 @@ const NewChat: NextPage = () => {
 
   const onSubmit = (values: FormValues) => createChat(values);
 
+  if (!isAuthenticated) {
+    return null;
+  }
+
+  console.log(errors);
+
   return (
     <Box display="flex" flexDirection="column" height="100%" width="100%">
       <Header showAvatar={true} />
@@ -166,7 +168,7 @@ const NewChat: NextPage = () => {
                     ...(errors.owner && { borderColor: "red" }),
                   }}
                 />
-                {errors.owner && (
+                {errors.owner?.message && (
                   <Text fontSize={0} marginTop={2}>
                     {errors.owner.message}
                   </Text>
@@ -196,7 +198,7 @@ const NewChat: NextPage = () => {
                     ...(errors.repo && { borderColor: "red" }),
                   }}
                 />
-                {errors.repo && (
+                {errors.repo?.message && (
                   <Text fontSize={0} marginTop={2}>
                     {errors.repo.message}
                   </Text>
@@ -205,7 +207,8 @@ const NewChat: NextPage = () => {
             </Box>
             {createChatError && (
               <Flash marginTop={3} sx={{ width: "100%" }} variant="danger">
-                {(createChatError as Error).message}
+                <StyledOcticon icon={XIcon} />
+                {(createChatError as Error)?.message || "Failed to create chat"}
               </Flash>
             )}
             <ButtonPrimary

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -55,7 +55,7 @@ const Home: NextPage = () => {
     <Box>
       <Header showAvatar={true} />
       <Box
-        bg="bg.primary"
+        bg="canvas.default"
         display="flex"
         flexDirection="row"
         alignItems="start"

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,13 +7,16 @@ import Message from "../components/message";
 import Header from "../components/header";
 import { useQuery } from "react-query";
 import { Chat } from "../types";
+import { useEffect } from "react";
 
 const Home: NextPage = () => {
   const router = useRouter();
 
-  // Need to refetch the chats based on this?
   const session = supabase.auth.session();
-  const userMeta = session?.user?.user_metadata;
+  const isAuthenticated = session !== null;
+  if (typeof window !== "undefined" && !isAuthenticated) {
+    router.push(`/login?redirect=/`);
+  }
 
   const {
     data: chats,
@@ -41,8 +44,12 @@ const Home: NextPage = () => {
       }
       return data?.map((entry) => entry.chat) || [];
     },
-    { enabled: true }
+    { enabled: isAuthenticated }
   );
+
+  if (!isAuthenticated) {
+    return null;
+  }
 
   return (
     <Box>

--- a/pages/invite/[code].tsx
+++ b/pages/invite/[code].tsx
@@ -1,42 +1,76 @@
-import type { NextPage } from 'next'
-import { useRouter } from 'next/router'
-import { Box, Text, ButtonDanger, ButtonPrimary, BranchName } from '@primer/components'
-import { supabase } from '../_app';
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import {
+  Box,
+  Text,
+  ButtonDanger,
+  ButtonPrimary,
+  BranchName,
+} from "@primer/components";
+import { supabase } from "../_app";
 import Header from "../../components/header";
 
 const JoinInvite: NextPage = () => {
   const router = useRouter();
-  const { code } = router.query
+  const { code } = router.query;
 
   const session = supabase.auth.session();
-  const isAuthenticated = session != null;
+  const isAuthenticated = session !== null;
 
-  const userMeta = session?.user?.user_metadata;
-
-  if (typeof window !== "undefined") {
-    if (!isAuthenticated) {
-      router.push(`/login?redirect=/invite/${code}`);
-    }
+  if (typeof window !== "undefined" && !isAuthenticated) {
+    router.push(`/login?redirect=/invite/${code}`);
+    return null;
   }
 
   return (
     <Box display="flex" flexDirection="column" height="100%" width="100%">
-     <Header showAvatar={true} />
-      <Box display="flex" flexDirection="column" justifyContent="center" alignItems="center" height="100%" width="100%">
-        <Box bg="bg.secondary" display="flex" flexDirection="column" justifyContent="center" alignItems="center" padding={4}>
-          <Text>Accepted invite to <BranchName>{"Author/RepoName"}</BranchName></Text>
-          <Box display="flex" marginTop={3} flexDirection="row" justifyContent="center" alignItems="center">
-            <ButtonPrimary onClick={() => {
-              // Leave the chat that you were just invited too!
-            }} marginRight={2}>Accept</ButtonPrimary>
-            <ButtonDanger onClick={() => {
-              // Leave the chat that you were just invited too!
-            }}>Cancel</ButtonDanger>
+      <Header showAvatar={true} />
+      <Box
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        height="100%"
+        width="100%"
+      >
+        <Box
+          bg="bg.secondary"
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          alignItems="center"
+          padding={4}
+        >
+          <Text>
+            Accepted invite to <BranchName>{"Author/RepoName"}</BranchName>
+          </Text>
+          <Box
+            display="flex"
+            marginTop={3}
+            flexDirection="row"
+            justifyContent="center"
+            alignItems="center"
+          >
+            <ButtonPrimary
+              onClick={() => {
+                // Leave the chat that you were just invited too!
+              }}
+              marginRight={2}
+            >
+              Accept
+            </ButtonPrimary>
+            <ButtonDanger
+              onClick={() => {
+                // Leave the chat that you were just invited too!
+              }}
+            >
+              Cancel
+            </ButtonDanger>
           </Box>
         </Box>
       </Box>
     </Box>
-  )
-}
+  );
+};
 
 export default JoinInvite;

--- a/pages/invite/[code].tsx
+++ b/pages/invite/[code].tsx
@@ -6,9 +6,12 @@ import {
   ButtonDanger,
   ButtonPrimary,
   BranchName,
+  ButtonInvisible,
+  ButtonOutline,
 } from "@primer/components";
 import { supabase } from "../_app";
 import Header from "../../components/header";
+import { MainActionBox } from "../../components/MainActionBox";
 
 const JoinInvite: NextPage = () => {
   const router = useRouter();
@@ -33,41 +36,30 @@ const JoinInvite: NextPage = () => {
         height="100%"
         width="100%"
       >
-        <Box
-          bg="bg.secondary"
-          display="flex"
-          flexDirection="column"
-          justifyContent="center"
-          alignItems="center"
-          padding={4}
-        >
-          <Text>
-            Accepted invite to <BranchName>{"Author/RepoName"}</BranchName>
+        <MainActionBox>
+          <Text as="h1" m={0} lineHeight={1}>
+            Join chat
           </Text>
-          <Box
-            display="flex"
-            marginTop={3}
-            flexDirection="row"
-            justifyContent="center"
-            alignItems="center"
+          <Text mt={5} textAlign="center">
+            Do you accept the invitation to{" "}
+            <BranchName>{"Author/RepoName"}</BranchName> ?
+          </Text>
+
+          <ButtonPrimary
+            mt={5}
+            // TODO
+            // disabled={isLoading}
+            variant="large"
+            width="100%"
+            // TODO
+            // onClick={() => handleSignIn()}
           >
-            <ButtonPrimary
-              onClick={() => {
-                // Leave the chat that you were just invited too!
-              }}
-              marginRight={2}
-            >
-              Accept
-            </ButtonPrimary>
-            <ButtonDanger
-              onClick={() => {
-                // Leave the chat that you were just invited too!
-              }}
-            >
-              Cancel
-            </ButtonDanger>
-          </Box>
-        </Box>
+            Accept
+          </ButtonPrimary>
+          <ButtonOutline mt={3} variant="large" width="100%">
+            Cancel
+          </ButtonOutline>
+        </MainActionBox>
       </Box>
     </Box>
   );

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,42 +1,81 @@
-import type { NextPage } from 'next'
-import { useRouter } from 'next/router'
-import { Box, ButtonPrimary } from '@primer/components'
-import { MarkGithubIcon } from '@primer/octicons-react'
-import { supabase } from './_app';
-import Header from '../components/header';
+import type { NextPage } from "next";
+import { useRouter } from "next/router";
+import {
+  Box,
+  ButtonPrimary,
+  Flash,
+  Spinner,
+  StyledOcticon,
+} from "@primer/components";
+import { MarkGithubIcon, XIcon } from "@primer/octicons-react";
+import { supabase } from "./_app";
+import Header from "../components/header";
+import { useMutation } from "react-query";
 
 const Home: NextPage = () => {
-  const router = useRouter()
+  const router = useRouter();
 
   const session = supabase.auth.session();
-  const isAuthenticated = session != null
+  const isAuthenticated = session !== null;
 
-  if(typeof window !== "undefined") {
+  if (typeof window !== "undefined") {
     if (isAuthenticated) {
       router.push("/");
     }
   }
 
+  const {
+    mutate: handleSignIn,
+    isLoading,
+    error,
+  } = useMutation(async () => {
+    const { error } = await supabase.auth.signIn(
+      { provider: "github" },
+      { scopes: "read:org,read:user,user:email" }
+    );
+
+    if (error) {
+      console.error(error);
+      throw error;
+    }
+
+    router.push("/");
+  });
+
   return (
     <Box display="flex" flexDirection="column" height="100%" width="100%">
       <Header showAvatar={false} />
-      <Box display="flex" flexDirection="column" justifyContent="start" alignItems="center" height="100%" width="100%">
-        <ButtonPrimary marginTop={5} onClick={async () => {
-          const { error } = await supabase.auth.signIn({
-            provider: "github",
-          }, {
-            scopes: "read:org,read:user,user:email"
-          });
-
-          if(error) {
-            console.error(error)
-            return;
-          }
-
-          router.push("/");
-        }}>
-          <Box display="flex" flexDirection="row" justifyContent="center" alignItems="center" height="100%" width="100%">
-            <MarkGithubIcon size={24} />
+      <Box
+        display="flex"
+        flexGrow={1}
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="center"
+        width="100%"
+      >
+        <MarkGithubIcon size="large" />
+        {error && (
+          <Flash variant="danger">
+            <StyledOcticon icon={XIcon} />
+            {(error as Error)?.message || "Failed to login"}
+          </Flash>
+        )}
+        <ButtonPrimary
+          marginTop={5}
+          disabled={isLoading}
+          variant="large"
+          width={256}
+          onClick={() => handleSignIn()}
+        >
+          <Box
+            display="flex"
+            flexDirection="row"
+            justifyContent="center"
+            alignItems="center"
+            height="100%"
+            width="100%"
+          >
+            {isLoading && <Spinner size="small" />}
             <Box marginLeft={2}>
               <span>Login with GitHub</span>
             </Box>
@@ -44,7 +83,7 @@ const Home: NextPage = () => {
         </ButtonPrimary>
       </Box>
     </Box>
-  )
-}
+  );
+};
 
-export default Home
+export default Home;

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -6,6 +6,7 @@ import {
   Flash,
   Spinner,
   StyledOcticon,
+  Text,
 } from "@primer/components";
 import { MarkGithubIcon, XIcon } from "@primer/octicons-react";
 import { supabase } from "./_app";
@@ -53,34 +54,49 @@ const Home: NextPage = () => {
         alignItems="center"
         width="100%"
       >
-        <MarkGithubIcon size="large" />
-        {error && (
-          <Flash variant="danger">
-            <StyledOcticon icon={XIcon} />
-            {(error as Error)?.message || "Failed to login"}
-          </Flash>
-        )}
-        <ButtonPrimary
-          marginTop={5}
-          disabled={isLoading}
-          variant="large"
-          width={256}
-          onClick={() => handleSignIn()}
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="center"
+          padding={8}
+          borderWidth={1}
+          borderStyle="solid"
+          borderColor="border.default"
+          borderRadius={16}
         >
-          <Box
-            display="flex"
-            flexDirection="row"
-            justifyContent="center"
-            alignItems="center"
-            height="100%"
-            width="100%"
+          <StyledOcticon icon={MarkGithubIcon} size="large" />
+          <Text as="h2" mt={4} mb={0}>
+            Github Chat
+          </Text>
+          {/* <MarkGithubIcon size="large" sx={{ marginBottom: 8 }} /> */}
+          {error && (
+            <Flash variant="danger" mt={4} sx={{ width: "100%" }}>
+              <StyledOcticon icon={XIcon} />
+              {(error as Error)?.message || "Failed to login"}
+            </Flash>
+          )}
+          <ButtonPrimary
+            marginTop={4}
+            disabled={isLoading}
+            variant="large"
+            width={256}
+            onClick={() => handleSignIn()}
           >
-            {isLoading && <Spinner size="small" />}
-            <Box marginLeft={2}>
-              <span>Login with GitHub</span>
+            <Box
+              display="flex"
+              flexDirection="row"
+              justifyContent="center"
+              alignItems="center"
+              height="100%"
+              width="100%"
+            >
+              {isLoading && <Spinner size="small" />}
+              <Box marginLeft={2}>
+                <span>Login with GitHub</span>
+              </Box>
             </Box>
-          </Box>
-        </ButtonPrimary>
+          </ButtonPrimary>
+        </Box>
       </Box>
     </Box>
   );

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -12,18 +12,13 @@ import { MarkGithubIcon, XIcon } from "@primer/octicons-react";
 import { supabase } from "./_app";
 import Header from "../components/header";
 import { useMutation } from "react-query";
+import { MainActionBox } from "../components/MainActionBox";
 
 const Home: NextPage = () => {
   const router = useRouter();
 
   const session = supabase.auth.session();
   const isAuthenticated = session !== null;
-
-  if (typeof window !== "undefined") {
-    if (isAuthenticated) {
-      router.push("/");
-    }
-  }
 
   const {
     mutate: handleSignIn,
@@ -43,6 +38,13 @@ const Home: NextPage = () => {
     router.push("/");
   });
 
+  if (typeof window !== "undefined") {
+    if (isAuthenticated) {
+      router.push("/");
+      return null;
+    }
+  }
+
   return (
     <Box display="flex" flexDirection="column" height="100%" width="100%">
       <Header showAvatar={false} />
@@ -54,29 +56,19 @@ const Home: NextPage = () => {
         alignItems="center"
         width="100%"
       >
-        <Box
-          display="flex"
-          flexDirection="column"
-          alignItems="center"
-          padding={8}
-          borderWidth={1}
-          borderStyle="solid"
-          borderColor="border.default"
-          borderRadius={16}
-        >
+        <MainActionBox>
           <StyledOcticon icon={MarkGithubIcon} size="large" />
-          <Text as="h2" mt={4} mb={0}>
+          <Text as="h1" mt={4} mb={0} lineHeight={1}>
             Github Chat
           </Text>
-          {/* <MarkGithubIcon size="large" sx={{ marginBottom: 8 }} /> */}
           {error && (
-            <Flash variant="danger" mt={4} sx={{ width: "100%" }}>
+            <Flash variant="danger" mt={5} sx={{ width: "100%" }}>
               <StyledOcticon icon={XIcon} />
               {(error as Error)?.message || "Failed to login"}
             </Flash>
           )}
           <ButtonPrimary
-            marginTop={4}
+            mt={6}
             disabled={isLoading}
             variant="large"
             width={256}
@@ -96,7 +88,7 @@ const Home: NextPage = () => {
               </Box>
             </Box>
           </ButtonPrimary>
-        </Box>
+        </MainActionBox>
       </Box>
     </Box>
   );


### PR DESCRIPTION
- For now in all pages, when the user is not logged in, redirect to `/login`
  - Make sure that we don't have a flash of rendered content before the redirect happens (by returning null in the render if not authenticated)
  - We can improve this later to show some relevant content to the non-logged user (public chats, etc)
- Fine tune the `/login` screen UI, handle error state if something fails
- Add a temporary `Logout` button in Header, just useful to quickly test login+logout. We can remove it or put it in a proper place later.
- Add UI for chat with empty message list

<img width="1280" alt="Screenshot 2021-10-04 at 11 42 42" src="https://user-images.githubusercontent.com/1535759/135821134-278056ca-c3b8-447d-97c3-703932e4f3ca.png">

<img width="1280" alt="Screenshot 2021-10-04 at 11 42 32" src="https://user-images.githubusercontent.com/1535759/135821157-b95e39a2-df05-4209-ac58-f6e7f7796ba4.png">

<img width="359" alt="Screenshot 2021-10-04 at 11 43 18" src="https://user-images.githubusercontent.com/1535759/135821180-30ef52d5-b9c2-4aca-b3ab-53753fa28545.png">

<img width="1280" alt="Screenshot 2021-10-04 at 11 17 23" src="https://user-images.githubusercontent.com/1535759/135821266-7550753f-947b-475c-98a2-28ce87e0b537.png">

