### PR TITLE
Fix partially redirect after login

### DIFF
--- a/pages/chats/[chatId].tsx
+++ b/pages/chats/[chatId].tsx
@@ -42,7 +42,9 @@ const ViewChat: NextPage = () => {
   const user = supabase.auth.user();
 
   const isAuthenticated = user !== null;
-  if (typeof window !== "undefined" && !isAuthenticated) {
+
+  // Check also for chatId because on first render router.query params are undefined
+  if (typeof window !== "undefined" && !isAuthenticated && chatId) {
     router.push(`/login?redirect=/chats/${chatId}`);
   }
 

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -17,6 +17,9 @@ import { Root } from "../components/Root";
 const Login: NextPage = () => {
   const router = useRouter();
 
+  const redirectPath =
+    typeof router.query.redirect === "string" ? router.query.redirect : "/";
+
   const session = supabase.auth.session();
   const isAuthenticated = session !== null;
 
@@ -24,10 +27,14 @@ const Login: NextPage = () => {
     mutate: handleSignIn,
     isLoading,
     error,
-  } = useMutation(async () => {
+  } = useMutation(async (redirectPath: string) => {
     const { error } = await supabase.auth.signIn(
       { provider: "github" },
-      { scopes: "read:org,read:user,user:email" }
+      {
+        // TODO Redirecting to specific path is not working for some reason
+        redirectTo: `${window.location.origin}${redirectPath}`,
+        scopes: "read:org,read:user,user:email",
+      }
     );
 
     if (error) {
@@ -71,7 +78,7 @@ const Login: NextPage = () => {
             disabled={isLoading}
             variant="large"
             width={256}
-            onClick={() => handleSignIn()}
+            onClick={() => handleSignIn(redirectPath)}
           >
             <Box
               display="flex"


### PR DESCRIPTION
Redirect to root after login. 

Redirecting to a specific path, e.g. to `/chats/<id>` is not working though, even though we are passing that URL to `supabase.auth.signIn({ provider: "github" }, { redirectTo })`. We can try to figure this out later.

Edit: Maybe it's because all redirect URLs have to be **exactly** specified in the Supabase Auth settings 🤔 And we are not able to do that with chat ids. Then, that's why Supabase is falling back to redirecting to root path.